### PR TITLE
Redirect to login on JWT expiry with client-side routing

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,6 +11,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-redux": "^9.3.0",
+        "react-router-dom": "^7.18.1",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0"
       },
@@ -1152,9 +1153,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1169,9 +1167,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1186,9 +1181,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1203,9 +1195,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1220,9 +1209,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1237,9 +1223,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,9 +1237,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1251,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,9 +1265,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,9 +1279,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,9 +1293,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,9 +1307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1356,9 +1321,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1899,6 +1861,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -2533,6 +2508,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2645,6 +2658,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-redux": "^9.3.0",
+    "react-router-dom": "^7.18.1",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0"
   },

--- a/front/src/components/App.jsx
+++ b/front/src/components/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { submitLogin, createAccount, readAccounts, updateAccount, deleteAccount, searchAccounts } from '../redux/Actions';
 import logo from '../logo.png';
 import './App.css';
@@ -30,20 +31,30 @@ export const App = props => {
       </header>
       <div className="App-body flex-column flex-center margin-small">
         <div className={messageClasses} data-testid="app-message">&nbsp;{props.message}</div>
-        {
-          !props.token &&
-          (<Login onSubmit={(username, password) => props.submitLogin(username, password)}></Login>)
-        }
-        {
-          props.token &&
-          (
-            <Table accounts={props.accounts}
-              onDelete={(index) => props.deleteAccount(index)}
-              onValidate={(index, account) => props.updateAccount(index, account)}
-              onCreate={(account) => props.createAccount(account)}>
-            </Table>
-          )
-        }
+        <Routes>
+          <Route
+            path="/login"
+            element={
+              props.token
+                ? <Navigate to="/" replace />
+                : <Login onSubmit={(username, password) => props.submitLogin(username, password)} />
+            }
+          />
+          <Route
+            path="/"
+            element={
+              props.token
+                ? (
+                  <Table accounts={props.accounts}
+                    onDelete={(index) => props.deleteAccount(index)}
+                    onValidate={(index, account) => props.updateAccount(index, account)}
+                    onCreate={(account) => props.createAccount(account)}>
+                  </Table>
+                )
+                : <Navigate to="/login" replace />
+            }
+          />
+        </Routes>
       </div>
     </div>
   );

--- a/front/src/components/App.test.jsx
+++ b/front/src/components/App.test.jsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 import { legacy_createStore as createStore, applyMiddleware } from 'redux';
 import { thunk } from 'redux-thunk';
 import App from './App';
@@ -11,7 +12,9 @@ describe('App', () => {
     const store = createStore(rootReducer, applyMiddleware(thunk));
     render(
       <Provider store={store}>
-        <App />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
       </Provider>
     );
 

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 
 import { Provider } from "react-redux";
 import store from "./redux/Store";
@@ -10,6 +11,8 @@ import App from './components/App';
 const rootElement = document.getElementById("root");
 createRoot(rootElement).render(
   <Provider store={store}>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </Provider>
 );

--- a/front/src/lib/errors.js
+++ b/front/src/lib/errors.js
@@ -5,7 +5,10 @@ export function processHttpStatus(response) {
     }
     return response.json();
 }
-export function manageError(error) {
+export function manageError(error, { logoutOnUnauthorized = false } = {}) {
+    if (logoutOnUnauthorized && error.status === 401) {
+        return Promise.resolve({ unauthorized: true });
+    }
     if (error.json) {
         return error.json().then(json => processPromiseError(json));
     } else {

--- a/front/src/lib/errors.test.js
+++ b/front/src/lib/errors.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { manageError } from './errors';
+
+describe('manageError', () => {
+  it('returns unauthorized marker for 401 when logout is requested', async () => {
+    const response = { status: 401, json: () => Promise.resolve({ message: 'expired' }) };
+    const result = await manageError(response, { logoutOnUnauthorized: true });
+    expect(result).toEqual({ unauthorized: true });
+  });
+
+  it('returns the API message for 401 on login requests', async () => {
+    const response = { status: 401, json: () => Promise.resolve({ message: 'Invalid credentials' }) };
+    const result = await manageError(response);
+    expect(result).toBe('Invalid credentials');
+  });
+});

--- a/front/src/redux/ActionTypes.js
+++ b/front/src/redux/ActionTypes.js
@@ -1,5 +1,6 @@
 export const SUBMIT_LOGIN_SUCCESS = 'SUBMIT_LOGIN_SUCCESS';
 export const SUBMIT_LOGIN_FAILURE = 'SUBMIT_LOGIN_FAILURE';
+export const LOGOUT = 'LOGOUT';
 
 export const SELECT_ROW = 'SELECT_ROW';
 export const UPDATE_NEW_ROW = 'UPDATE_NEW_ROW';

--- a/front/src/redux/Actions.js
+++ b/front/src/redux/Actions.js
@@ -1,7 +1,8 @@
 import { manageError, processHttpStatus } from '../lib/errors';
 import { 
   SUBMIT_LOGIN_SUCCESS, 
-  SUBMIT_LOGIN_FAILURE, 
+  SUBMIT_LOGIN_FAILURE,
+  LOGOUT,
   READ_ACCOUNTS_SUCCESS, 
   READ_ACCOUNTS_FAILURE, 
   DELETE_ACCOUNT_SUCCESS,
@@ -39,6 +40,18 @@ const deleteRequest = {
   method: 'DELETE'
 };
 
+const handleAuthError = (dispatch, failureAction) => error =>
+  manageError(error, { logoutOnUnauthorized: true })
+    .then(result => {
+      if (result?.unauthorized) {
+        dispatch(logout());
+        return;
+      }
+      if (failureAction) {
+        dispatch(failureAction(result));
+      }
+    });
+
 ///
 /// LOGIN ACTIONS
 ///
@@ -59,6 +72,10 @@ export const submitLoginSuccess = (username, token) => ({
 export const submitLoginFailure = message => ({
   type: SUBMIT_LOGIN_FAILURE,
   payload: { message }
+});
+
+export const logout = () => ({
+  type: LOGOUT
 });
 
 ///
@@ -84,8 +101,7 @@ export const createAccount = account => (dispatch, getState) => {
   fetch(`${url}/password`, authHeader(getState().connectedUser.token, post))
     .then(response => processHttpStatus(response))
     .then(() => dispatch(createAccountSuccess(account)))
-    .catch(error => manageError(error)
-    .then(message => dispatch(createAccountFailure(message))));
+    .catch(error => handleAuthError(dispatch, createAccountFailure)(error));
 };
 
 export const createAccountSuccess = account => ({
@@ -107,8 +123,7 @@ export const readAccounts = searchFilter => (dispatch, getState) => {
   fetch(readUrl, authHeader(getState().connectedUser.token))
     .then(response => processHttpStatus(response))
     .then(json => dispatch(readAccountsSuccess(json)))
-    .catch(error => manageError(error)
-    .then(message => dispatch(readAccountsFailure(message))));
+    .catch(error => handleAuthError(dispatch, () => readAccountsFailure())(error));
 }
 
 export const readAccountsSuccess = accounts => ({
@@ -151,8 +166,7 @@ export const updateAccount = (index, account) => (dispatch, getState) => {
   fetch(`${url}/password`, authHeader(getState().connectedUser.token, put))
   .then(response => processHttpStatus(response))
   .then(() => dispatch(updateAccountSuccess(index, account)))
-  .catch(error => manageError(error)
-  .then(message => dispatch(updateAccountFailure(message))));
+  .catch(error => handleAuthError(dispatch, updateAccountFailure)(error));
 };
 
 export const updateAccountSuccess = (index, account) => ({
@@ -174,8 +188,7 @@ export const deleteAccount = index => (dispatch, getState) => {
   fetch(`${url}/password/${getState().accountList.accounts[index].id}`, authHeader(getState().connectedUser.token, delete_))
   .then(response => processHttpStatus(response))
   .then(() => dispatch(deleteAccountSuccess(index)))
-  .catch(error => manageError(error)
-  .then(message => dispatch(deleteAccountFailure(message))));
+  .catch(error => handleAuthError(dispatch, deleteAccountFailure)(error));
 };
 
 export const deleteAccountSuccess = index => ({

--- a/front/src/redux/reducers/ConnectedUser.js
+++ b/front/src/redux/reducers/ConnectedUser.js
@@ -1,4 +1,4 @@
-import { SUBMIT_LOGIN_SUCCESS } from '../ActionTypes';
+import { SUBMIT_LOGIN_SUCCESS, LOGOUT } from '../ActionTypes';
 
 const initialState = {
     username: null, token: null
@@ -9,6 +9,8 @@ export default function (state = initialState, action) {
     switch (action.type) {
         case SUBMIT_LOGIN_SUCCESS: 
             return { username: action.payload.username, token: action.payload.token, message: null};
+        case LOGOUT:
+            return initialState;
         default:
             return state;
     }

--- a/front/src/redux/reducers/ErrorManagement.js
+++ b/front/src/redux/reducers/ErrorManagement.js
@@ -1,6 +1,7 @@
 import {
   SUBMIT_LOGIN_SUCCESS,
   SUBMIT_LOGIN_FAILURE,
+  LOGOUT,
   READ_ACCOUNTS_SUCCESS,
   READ_ACCOUNTS_FAILURE,
   DELETE_ACCOUNT_SUCCESS,
@@ -24,6 +25,7 @@ export default function (state = initialState, action) {
     case CREATE_ACCOUNT_FAILURE:
     case UPDATE_ACCOUNT_FAILURE:
       return { message: action.payload.message };
+    case LOGOUT:
     case SUBMIT_LOGIN_SUCCESS:
     case READ_ACCOUNTS_SUCCESS:
     case DELETE_ACCOUNT_SUCCESS:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the JWT expired, authenticated API calls returned 401 but the app kept the stale token and failed silently. This adds client-side routes and redirects to the login page on 401.

## Changes

- Add **React Router** with two routes:
  - `/login` — login form
  - `/` — account list (protected)
- On **401** from authenticated API requests (`/api/password*`), dispatch `logout()` to clear auth state; the route guard then redirects to `/login`.
- Login failures still show the API error message (401 on `/api/login` is not treated as a session expiry).
- Add unit tests for 401 error handling.

## Testing

- `npm test` (frontend unit tests) — passed
- `npm run verify` (DB setup, unit tests, build, API integration, preview) — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b04450c3-e3a5-41cf-a292-6f9c5e773def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b04450c3-e3a5-41cf-a292-6f9c5e773def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

